### PR TITLE
Feature/emit lifecycle events

### DIFF
--- a/config.js
+++ b/config.js
@@ -192,17 +192,13 @@ var plugins = [
 
 /*
   ----------------------------
-  NGROK
+  LOCALTUNNEL
   ----------------------------
 */
-var ngrok;
-if(process.env.NGROK_AUTHTOKEN) {
-  ngrok = {
-    port: serverPort,
-    authtoken: process.env.NGROK_AUTHTOKEN,
-    subdomain: libName,
-  };
-}
+var localtunnel = {
+  subdomain: libName.toLowerCase().replace(/[-_]/g, ''),
+};
+
 
 /*
   ----------------------------
@@ -253,7 +249,7 @@ module.exports = {
   displayName: displayName,
 
   hotReload: hotReload,
-  ngrok: ngrok,
+  localtunnel: localtunnel,
   cloudfront: cloudfront,
 
   files: files,

--- a/gulp_tasks/localtunnel.js
+++ b/gulp_tasks/localtunnel.js
@@ -1,0 +1,21 @@
+var localtunnel = require('localtunnel');
+var gutil = require("gulp-util");
+var assign = require("object-assign");
+
+// Setup a localtunnel server
+module.exports = function(gulp, config) {
+
+  gulp.task('localtunnel', function(callback) {
+    console.log(config.localtunnel)
+    var tunnel = localtunnel(config.serverPort, config.localtunnel, function(error, tunnel) {
+      if (error) throw new gutil.PluginError('ship:server', error);
+      var url = tunnel.url.replace('https', 'http');
+      gutil.log('[ship:server]', url);
+      callback(tunnel)
+    });
+    if (!config.localtunnel) {
+      return callback();
+    }
+  });
+
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,7 +13,7 @@ var config      = require('./config');
   'deploy',
   'format',
   'lint',
-  // 'ngrok',
+  'localtunnel',
   'webpack',
   // 'iconfont',
   // 'iconsprite',
@@ -34,7 +34,7 @@ gulp.task('watch', function(callback) {
 });
 
 gulp.task('serve', function(callback) {
-  runSequence(['webpack:server'], callback);
+  runSequence(['webpack:server','localtunnel'], callback);
 });
 
 // Batch, Public Tasks

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "json-loader": "^0.5.3",
     "less": "^2.5.3",
     "less-loader": "^2.2.1",
+    "localtunnel": "^1.8.1",
     "merge-stream": "^1.0.0",
     "moment": "^2.9.0",
     "ngrok": "^0.2.2",

--- a/src/components/form/templates/select.jsx
+++ b/src/components/form/templates/select.jsx
@@ -5,7 +5,7 @@ import styles from '../form.css';
 const Select = React.createClass({
   propTypes: {
     onChange: PropTypes.func.isRequired,
-    options: PropTypes.array.isRequired
+    options: PropTypes.array.isRequired,
   },
 
   handleChange(e) {

--- a/src/lib/engine/index.js
+++ b/src/lib/engine/index.js
@@ -512,7 +512,7 @@ export default class Engine extends EventEmitter {
 
     let location = options.redirect_url;
 
-    const origin = window.location.origin || window.location.protocol + '//' + window.location.hostname + (window.location.port ? ':' + window.location.port: '');
+    const origin = window.location.origin || window.location.protocol + '//' + window.location.hostname + (window.location.port ? ':' + window.location.port : '');
 
     if (this.isShopifyCustomer()) {
       if (parseQueryString().checkout_url) {

--- a/src/lib/engine/index.js
+++ b/src/lib/engine/index.js
@@ -4,6 +4,8 @@ import { EventEmitter } from 'events';
 import * as Backends from './backends';
 import { parseQueryString } from '../utils';
 
+const SHIP_NAMESPACE = 'hull.login';
+
 const USER_SECTIONS = [
   'showProfile',
   'editProfile',
@@ -74,7 +76,7 @@ export default class Engine extends EventEmitter {
     });
 
     _.each(this.getActions(), (a, k) => {
-      this._hull.on('hull.login.' + k, (options) => {
+      this._hull.on(`${SHIP_NAMESPACE}.${k}`, (options) => {
         this._transientOptions = options;
         a();
       });
@@ -146,6 +148,10 @@ export default class Engine extends EventEmitter {
 
   emitChange() {
     this.emit(EVENT);
+  }
+
+  hullEmit(event = '', options = {}) {
+    this._hull.emit(`${SHIP_NAMESPACE}.${event}`, options);
   }
 
   getStorageKey() {
@@ -277,11 +283,14 @@ export default class Engine extends EventEmitter {
 
   showDialog() {
     const section = this._returningUser ? 'logIn' : 'signUp';
-    return this.activateSection(section);
+    const result = this.activateSection(section);
+    this.hullEmit('dialogShown');
+    return result;
   }
 
   hideDialog() {
     this.saveState({ dialogHidden: true, completeSignup: null });
+
 
     this.clearTimers();
 
@@ -289,11 +298,13 @@ export default class Engine extends EventEmitter {
       this.redirect();
     }
 
+
     this._dialogIsVisible = false;
     this._activeSection = null;
 
     this._transientOptions = {};
     this.emitChange();
+    this.hullEmit('dialogHidden');
   }
 
   signUp(credentials) {
@@ -565,6 +576,7 @@ export default class Engine extends EventEmitter {
       this._activeSection = name;
       this._errors = {};
       this.emitChange();
+      this.hullEmit(`${name}SectionActivated`);
     } else {
       throw new Error('"' + name + '" is not a valid section name');
     }

--- a/src/readme.md
+++ b/src/readme.md
@@ -83,6 +83,22 @@ The dialog can be controlled by triggering events. with the `Hull.emit` function
 
 `options` is an optional Object passed to the next call to Hull.login() or Hull.signup(). It will persist as long as the modal is open, and disappear when it's dismissed. This way customers can switch between different tabs and sections without losing context.
 
-It is useful to specify redirect strategies with `options.strategy`, or redirect URLs with `options.redirect_url` [Checkout the Hull.js Documentation](http://www.hull.io/docs/references/hull_js/#user-signup-and-login) for all supported options.
+It is useful to specify redirect strategies with `options.strategy`, or redirect URLs with `options.redirect_url`. You can also prepopulate the user's email via `options.email`
 
-You can also prepopulate the user's email via `options.email`;
+[Checkout the Hull.js Documentation](http://www.hull.io/docs/references/hull_js/#user-signup-and-login) for all supported options.
+
+
+#### Emitted Events
+
+To listen to Hull lifecycle events such as logging in and out, please use [Hull.js's events directly](http://www.hull.io/docs/references/hull_js/#events).
+
+The dialog emits additional events when it's status changes. Those aren't synchronized to actual logins and signups. They're UI-related.
+
+- `Hull.on('hull.login.dialogShown')`
+- `Hull.on('hull.login.dialogHidden')`
+- `Hull.on('hull.login.showProfileSectionActivated')`
+- `Hull.on('hull.login.editProfileSectionActivated')`
+- `Hull.on('hull.login.thanksSectionActivated')`
+- `Hull.on('hull.login.logInSectionActivated')`
+- `Hull.on('hull.login.signUpSectionActivated')`
+- `Hull.on('hull.login.resetPasswordSectionActivated')`


### PR DESCRIPTION
@sbellity This allows the other ships to listen to a "hull.login.dialogHidden" event and resume the previous action.

Also switches to localtunnel. Do `npm install`

cc @sbellity 